### PR TITLE
Update SDK to 41

### DIFF
--- a/uk.jnthn.backgammony.json
+++ b/uk.jnthn.backgammony.json
@@ -1,7 +1,7 @@
 {
     "app-id": "uk.jnthn.backgammony",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "40",
+    "runtime-version": "41",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.dmd"


### PR DESCRIPTION
DMD is now available for freedesktop-sdk 21.08, which Gnome SDK 41 is based on.